### PR TITLE
Adds DROP command for s3_video_stills table

### DIFF
--- a/includes/plugin_setup.php
+++ b/includes/plugin_setup.php
@@ -36,5 +36,6 @@ class s3_video_plugin_setup
 		mysql_query("DROP TABLE IF EXISTS `s3_video_playlists`") or die(mysql_error());		
 		mysql_query("DROP TABLE IF EXISTS `s3_video_playlist_videos`") or die(mysql_error());	
 		mysql_query("DROP TABLE IF EXISTS `s3_video_analytics`") or die(mysql_error());			
+		mysql_query("DROP TABLE IF EXISTS `s3_video_stills`") or die(mysql_error());		
 	}
 } 


### PR DESCRIPTION
On deactivation of the plugin the `s3_video_stills` table is not removed.

**Steps to reproduce:**
1. Install WordPress
2. Activate s3-video plugin and view tables created
3. Deactivate s3-video plugin and view difference in tables

**Fix:**

Add mysql query to drop s3_video_stills table.
